### PR TITLE
Remove vercel, keyauth, and related domains

### DIFF
--- a/validin-phish-feed-1.txt
+++ b/validin-phish-feed-1.txt
@@ -12848,12 +12848,9 @@ topindian365.com
 
 8rp.xyz
 agentchairs.xyz
-aimr.dev
 alorastore.xyz
 aorfxs.shop
-appolon.dev
 ariez.wtf
-autoplus.gg
 betboost.shop
 boostplaza.us
 boostuniverse.to
@@ -12887,7 +12884,6 @@ hwdvirtualizer.com
 hzrd.media
 icegen.xyz
 intellectcheats.xyz
-keyauth.com
 keymart.vip
 kingcheats.net
 kreamy.dev
@@ -12929,23 +12925,19 @@ unbound.software
 usehorizon.net
 vantageshops.eu
 vbucksgenerator.zip
-vercel-dns.com
 verify.starlightzone
 vexhub.dev
 whitenigger.site
 x2saddddm.lol
 xd.mk
 zeusshop.cc
-bwt.appolon.dev
 cf.dailyadultfolders.com
-cname.vercel-dns.com
 dev.verify.starlightzone.xyz
 discord-stealer.de
 discord-verify.sytes.net
 enforce.astroservers.online
 mak.kreamy.dev
 mtcm.sytes.net
-restore.autoplus.gg
 support.securitybot.vip
 tawashi-verify.sytes.net
 test1.kreamy.dev
@@ -12955,7 +12947,6 @@ v.macrov3.support
 ver1.dexverify.cc
 verify.8rp.xyz
 verify.agentchairs.xyz
-verify.aimr.dev
 verify.alorastore.xyz
 verify.aorfxs.shop
 verify.ariez.wtf
@@ -13028,7 +13019,6 @@ verify.vexhub.dev
 verify.whitenigger.site
 verify.x2saddddm.lol
 verify.xd.mk
-verify1.keyauth.com
 verifytenance.zeusshop.cc
 weryfikacja.nudesy.fun
 zero0day.ddns.net


### PR DESCRIPTION
@MikhailKasimov there are enough from the original list that are benign that it might be better to remove the entire list (from this section), and add back only validated domains.