### PR TITLE
Remove gmail.com from validin-phish-feed-5.txt

### DIFF
--- a/validin-phish-feed-5.txt
+++ b/validin-phish-feed-5.txt
@@ -103262,7 +103262,6 @@ givofe.company
 gizaici.za.com
 gizooji.cloud
 gjeypk.es
-gmail.com
 gocrohou.firm.in
 goheape.ru
 gojiochou.biz.id


### PR DESCRIPTION
Removed 'gmail.com' from the phishing feed list.